### PR TITLE
bin/public-inbox-tg: Use encoded $msgId for url

### DIFF
--- a/bin/public-inbox-tg.php
+++ b/bin/public-inbox-tg.php
@@ -204,7 +204,7 @@ function fx(string $input): int
 			[
 				[
 					"text" => "See the full message",
-					"url" => "https://lore.gnuweeb.org/gwml/{$msgId}",
+					"url" => "https://lore.gnuweeb.org/gwml/".urlencode($msgId),
 				]
 			]
 		]


### PR DESCRIPTION
Lore $msgId are always contains non alpha-numberic character, reported by Alviro that he are facing 404 because of unencoded $msgId

Signed-off-by: Rubi <weeb@gnuweeb.org>
Reviewed-by: Alviro Iskandar Setiawan <alviro.iskandar@gnuweeb.org>